### PR TITLE
Jeroo context

### DIFF
--- a/jeroo/README.md
+++ b/jeroo/README.md
@@ -1,0 +1,5 @@
+### Jeroo stack script
+
+Installs opam, nodejs
+
+On finish executing the script reload the box.

--- a/jeroo/files/scripts/jeroo-opam.sh
+++ b/jeroo/files/scripts/jeroo-opam.sh
@@ -3,7 +3,7 @@
 cd /home/codio/jeroo/jeroo
 cd src/compiler
 
-opam init --disable-sandboxing --bare
+opam init --disable-sandboxing --bare -a
 opam switch create ./ ocaml-base-compiler.4.08.1
 opam install --deps-only . -y
 eval $(opam env)

--- a/jeroo/files/scripts/jeroo-opam.sh
+++ b/jeroo/files/scripts/jeroo-opam.sh
@@ -3,6 +3,7 @@
 cd /home/codio/jeroo/jeroo
 cd src/compiler
 
+eval $(opam env)
 opam init --disable-sandboxing --bare
 opam switch create ./ ocaml-base-compiler.4.08.1
 opam install --deps-only . -y

--- a/jeroo/files/scripts/jeroo-opam.sh
+++ b/jeroo/files/scripts/jeroo-opam.sh
@@ -3,7 +3,6 @@
 cd /home/codio/jeroo/jeroo
 cd src/compiler
 
-eval $(opam env)
 opam init --disable-sandboxing --bare
 opam switch create ./ ocaml-base-compiler.4.08.1
 opam install --deps-only . -y

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -4,7 +4,7 @@
 
   tasks:
     - name: Add nodesource repository
-      shell: curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
+      shell: curl -fsSL https://deb.nodesource.com/setup_16.x | sudo bash -
 
     - name: Add Yarn keyring
       shell: curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/yarnkey.gpg

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -6,14 +6,26 @@
     - name: Add nodesource repository
       shell: curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
 
-    - name: Add APT key
-      apt_key:
-        url: https://dl.yarnpkg.com/debian/pubkey.gpg
-        state: present
+    # - name: Add APT key
+    #   apt_key:
+    #     url: https://dl.yarnpkg.com/debian/pubkey.gpg
+    #     state: present
 
-    - name: Add APT repository
+    # - name: Add APT repository
+    #   apt_repository:
+    #     repo: deb https://dl.yarnpkg.com/debian/ stable main
+    #     state: present
+
+    - name: Add Yarn keyring
+      get_url:
+        url: https://dl.yarnpkg.com/debian/pubkey.gpg
+        dest: /usr/share/keyrings/yarn.gpg
+        mode: '0644'
+
+    - name: Add Yarn APT repository
       apt_repository:
-        repo: deb https://dl.yarnpkg.com/debian/ stable main
+        repo: "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian stable main"
+        filename: yarn
         state: present
 
     - name: Update apt cache
@@ -41,10 +53,20 @@
       get_url:
         url: https://github.com/ocaml/opam/releases/download/2.4.1/opam-2.4.1-x86_64-linux
         dest: ./opam-2.4.1-x86_64-linux
+        mode: '0755'
+        checksum: "sha256:30da8eb20c8f4cfd3818db867d85f26df1ca5ca27cb25910c0235c5a02e12d3b"
       when: not opam_installer.stat.exists
 
-    - name: Add Opam repository
-      shell: install ./opam-2.4.1-x86_64-linux /usr/local/bin/opam
+    # - name: Add Opam repository
+    #   shell: install ./opam-2.4.1-x86_64-linux /usr/local/bin/opam
+    - name: Install opam binary
+      copy:
+        src: /usr/local/src/opam-2.4.1-x86_64-linux
+        dest: /usr/local/bin/opam
+        mode: '0755'
+        owner: root
+        group: root
+        remote_src: true
 
     # Jeroo
     - name: Jeroo checkout
@@ -57,9 +79,16 @@
         force: yes
         version: master
 
-    - copy: src=jeroo.prod.conf.ts dest=/home/codio/jeroo/jeroo/src/environments/environment.prod.ts
-    - copy: src=scripts/jeroo-opam.sh dest=/tmp/jeroo-opam.sh mode=0777
-    - copy: src=scripts/yarn-jeroo.sh dest=/tmp/yarn-jeroo.sh mode=0777
+    # - copy: src=jeroo.prod.conf.ts dest=/home/codio/jeroo/jeroo/src/environments/environment.prod.ts
+    - copy:
+        src: jeroo.prod.conf.ts
+        dest: /home/codio/jeroo/jeroo/src/environments/environment.prod.ts
+        owner: codio
+        group: codio
+        mode: '0644'
+
+    - copy: src=scripts/jeroo-opam.sh dest=/tmp/jeroo-opam.sh mode=0755
+    - copy: src=scripts/yarn-jeroo.sh dest=/tmp/yarn-jeroo.sh mode=0755
 
     - name: Yarn jeroo build compiler
       shell: sh /tmp/jeroo-opam.sh
@@ -90,7 +119,7 @@
         version: master
 
     - copy: src=jeroo-server.conf.json dest=/home/codio/jeroo/jeroo-server/config.json
-    - copy: src=scripts/yarn-jeroo-server.sh dest=/tmp/yarn-jeroo-server.sh mode=0777
+    - copy: src=scripts/yarn-jeroo-server.sh dest=/tmp/yarn-jeroo-server.sh mode=0755
 
     - name: jeroo server - yarn install
       become: yes
@@ -104,10 +133,22 @@
       become: yes
       become_user: codio
 
-    - copy: src=scripts/jeroo-server.sh dest=/home/codio/jeroo/jeroo-server/jeroo-server.sh mode=0777
-    - copy: src=systemd/jeroo-server.service dest=/etc/systemd/system/jeroo-server.service
+    - copy: src=scripts/jeroo-server.sh dest=/home/codio/jeroo/jeroo-server/jeroo-server.sh mode=0755
+    # - copy: src=systemd/jeroo-server.service dest=/etc/systemd/system/jeroo-server.service
+    - copy:
+        src: systemd/jeroo-server.service
+        dest: /etc/systemd/system/jeroo-server.service
+        owner: root
+        group: root
+        mode: '0644'
 
-    - service: name=jeroo-server state=restarted enabled=true
+    # - service: name=jeroo-server state=restarted enabled=true
+    - systemd:
+        name: jeroo-server
+        enabled: true
+        state: restarted
+        daemon_reload: true
+
 
 - hosts: 127.0.0.1
   become: true
@@ -120,12 +161,14 @@
           - index index.html
           - location / {
               root /home/codio/jeroo/jeroo/dist/jeroo;
-              try_files $uri /index.html break;
+              try_files $uri $uri/ /index.html;
             }
           - location ^~ /jeroo-server-service/ {
-              proxy_pass http://0.0.0.0:7500/;
+              proxy_pass http://127.0.0.1:7500/;
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
               proxy_http_version 1.1;
               proxy_cache off;
               proxy_buffering off;

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -17,11 +17,11 @@
         state: present
 
     - name: Update apt cache
-      ansible.builtin.apt:
+      apt:
         update_cache: yes
 
     - name: Install required packages
-      ansible.builtin.apt:
+      apt:
         name:
           - nodejs
           - build-essential
@@ -33,12 +33,12 @@
 
     # Install Opam
     - name: Check opam installer exists
-      ansible.builtin.stat:
+      stat:
         path: ./opam-2.4.1-x86_64-linux
       register: opam_installer
 
     - name: Get Opam
-      ansible.builtin.get_url:
+      get_url:
         url: https://github.com/ocaml/opam/releases/download/2.4.1/opam-2.4.1-x86_64-linux
         dest: ./opam-2.4.1-x86_64-linux
       when: not opam_installer.stat.exists

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -22,6 +22,10 @@
         dest: /usr/share/keyrings/yarn.gpg
         mode: '0644'
 
+    - name: Dearmor yarn.gpg
+      become: yes
+      shell: gpg --yes --dearmor -o /usr/share/keyrings/yarn.gpg
+
     - name: Add Yarn APT repository
       apt_repository:
         repo: "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian stable main"

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -126,12 +126,22 @@
         group: root
         mode: '0644'
 
-    # - service: name=jeroo-server state=restarted enabled=true
-    - systemd:
-        name: jeroo-server
-        enabled: true
-        state: restarted
-        daemon_reload: true
+    - name: check jeroo.service enabled
+      shell: systemctl is-enabled jeroo-server | grep enabled
+      register: jeroo_enabled
+      ignore_errors: true
+
+    - name: enable service
+      shell: systemctl enable jeroo-server
+      when: jeroo_enabled.rc == 1
+
+    - name: start service
+      shell: systemctl start jeroo-server
+      when: jeroo_enabled.rc == 1
+
+    - name: reload systemd daemon
+      systemd:
+        daemon_reload: yes
 
 
 - hosts: 127.0.0.1

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -6,31 +6,11 @@
     - name: Add nodesource repository
       shell: curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
 
-    # - name: Add APT key
-    #   apt_key:
-    #     url: https://dl.yarnpkg.com/debian/pubkey.gpg
-    #     state: present
-
-    # - name: Add APT repository
-    #   apt_repository:
-    #     repo: deb https://dl.yarnpkg.com/debian/ stable main
-    #     state: present
-
     - name: Add Yarn keyring
-      get_url:
-        url: https://dl.yarnpkg.com/debian/pubkey.gpg
-        dest: /usr/share/keyrings/yarn.gpg
-        mode: '0644'
-
-    - name: Dearmor yarn.gpg
-      become: yes
-      shell: gpg --yes --dearmor -o /usr/share/keyrings/yarn.gpg
+      shell: curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/yarnkey.gpg
 
     - name: Add Yarn APT repository
-      apt_repository:
-        repo: "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian stable main"
-        filename: yarn
-        state: present
+      shell: echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | sudo tee /etc/apt/sources.list.d/yarn.list > /dev/null
 
     - name: Update apt cache
       apt:

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -167,3 +167,8 @@
               proxy_cache off;
               proxy_buffering off;
             }
+
+  tasks:
+    - name: reload systemd daemon
+      systemd:
+        daemon_reload: yes

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -61,7 +61,7 @@
         dest: /home/codio/jeroo/jeroo
         update: yes
         force: yes
-        version: 16804_jeroo_context
+        version: master
 
     # - copy: src=jeroo.prod.conf.ts dest=/home/codio/jeroo/jeroo/src/environments/environment.prod.ts
     - copy:

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -61,7 +61,7 @@
         dest: /home/codio/jeroo/jeroo
         update: yes
         force: yes
-        version: master
+        version: 16804_jeroo_context
 
     # - copy: src=jeroo.prod.conf.ts dest=/home/codio/jeroo/jeroo/src/environments/environment.prod.ts
     - copy:

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -45,7 +45,7 @@
     #   shell: install ./opam-2.4.1-x86_64-linux /usr/local/bin/opam
     - name: Install opam binary
       copy:
-        src: /usr/local/src/opam-2.4.1-x86_64-linux
+        src: ./opam-2.4.1-x86_64-linux
         dest: /usr/local/bin/opam
         mode: '0755'
         owner: root

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -1,29 +1,10 @@
 ---
 - hosts: 127.0.0.1
   become: true
-  roles:
-    - role: jdauphant.nginx
-      nginx_sites:
-        jeroo:
-          - listen 7501
-          - client_max_body_size 150m
-          - index index.html
-          - location / {
-              root /home/codio/jeroo/jeroo/dist/jeroo;
-              try_files $uri /index.html break;
-            }
-          - location ^~ /jeroo-server-service/ {
-              proxy_pass http://0.0.0.0:7500/;
-              proxy_set_header Host $host;
-              proxy_set_header X-Real-IP $remote_addr;
-              proxy_http_version 1.1;
-              proxy_cache off;
-              proxy_buffering off;
-            }
 
   tasks:
     - name: Add nodesource repository
-      shell: curl -sL https://deb.nodesource.com/setup_16.x | bash -
+      shell: curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
 
     - name: Add APT key
       apt_key:
@@ -35,27 +16,34 @@
         repo: deb https://dl.yarnpkg.com/debian/ stable main
         state: present
 
-    - apt: update_cache=yes
-    - apt: name=nodejs state=present
-    - apt: name=build-essential state=present
-    - apt: name=yarn state=present
-    - apt: name=systemd state=latest
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: yes
 
-    - apt: name=zip state=present
-    - apt: name=bubblewrap state=present
+    - name: Install required packages
+      ansible.builtin.apt:
+        name:
+          - nodejs
+          - build-essential
+          - yarn
+          - systemd
+          - zip
+          - bubblewrap
+        state: present
 
     # Install Opam
     - name: Check opam installer exists
       stat:
-        path: ./opam-2.0.8-x86_64-linux
+        path: ./opam-2.4.1-x86_64-linux
       register: opam_installer
 
     - name: Get Opam
       shell: wget https://github.com/ocaml/opam/releases/download/2.0.8/opam-2.0.8-x86_64-linux
+      https://github.com/ocaml/opam/releases/download/2.4.1/opam-2.4.1-x86_64-linux
       when: not opam_installer.stat.exists
 
     - name: Add Opam repository
-      shell: install ./opam-2.0.8-x86_64-linux /usr/local/bin/opam
+      shell: install ./opam-2.4.1-x86_64-linux /usr/local/bin/opam
 
     # Jeroo
     - name: Jeroo checkout
@@ -119,3 +107,25 @@
     - copy: src=systemd/jeroo-server.service dest=/etc/systemd/system/jeroo-server.service
 
     - service: name=jeroo-server state=restarted enabled=true
+
+- hosts: 127.0.0.1
+  become: true
+  roles:
+    - role: jdauphant.nginx
+      nginx_sites:
+        jeroo:
+          - listen 7501
+          - client_max_body_size 150m
+          - index index.html
+          - location / {
+              root /home/codio/jeroo/jeroo/dist/jeroo;
+              try_files $uri /index.html break;
+            }
+          - location ^~ /jeroo-server-service/ {
+              proxy_pass http://0.0.0.0:7500/;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_http_version 1.1;
+              proxy_cache off;
+              proxy_buffering off;
+            }

--- a/jeroo/playbook.yaml
+++ b/jeroo/playbook.yaml
@@ -33,13 +33,14 @@
 
     # Install Opam
     - name: Check opam installer exists
-      stat:
+      ansible.builtin.stat:
         path: ./opam-2.4.1-x86_64-linux
       register: opam_installer
 
     - name: Get Opam
-      shell: wget https://github.com/ocaml/opam/releases/download/2.0.8/opam-2.0.8-x86_64-linux
-      https://github.com/ocaml/opam/releases/download/2.4.1/opam-2.4.1-x86_64-linux
+      ansible.builtin.get_url:
+        url: https://github.com/ocaml/opam/releases/download/2.4.1/opam-2.4.1-x86_64-linux
+        dest: ./opam-2.4.1-x86_64-linux
       when: not opam_installer.stat.exists
 
     - name: Add Opam repository


### PR DESCRIPTION
https://bugtracker.codiodev.com/issue/codio-16804/Jeroo-files-do-not-work-with-LLM-grader-on-clicking-check-it-error-says-no-open-files-to-submit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Reintroduced role-driven web server site to serve the app on port 7501 and proxy backend to localhost:7500 with more forgiving asset routing.

- Refactor
  - Consolidated and modernized provisioning (Node 22, Yarn repository, unified apt tasks) and clarified deployment steps with explicit ownership, executable scripts, and managed service restarts.

- Chores
  - Upgraded Opam installer to a newer release and added apt cache/update and package installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->